### PR TITLE
Plugin is not getting activated

### DIFF
--- a/api/import.php
+++ b/api/import.php
@@ -38,7 +38,7 @@ class BookeasyOperators_Import extends Bookeasy{
      * Start up
      */
     public function __construct(){
-        $this->tz = new DateTimeZone(get_option('timezone_string'));
+        $this->tz = new DateTimeZone(date_default_timezone_get());
         $this->tzUTC = new DateTimeZone('UTC');
 
         //returning for chaining


### PR DESCRIPTION
Getting Fatal error:

Uncaught exception 'Exception' with message 'DateTimeZone::__construct() [datetimezone.--construct]: Unknown or bad timezone ()' in /html/gadgets/wp-content/plugins/bookeasy/api/import.php:41

Line 41 updated to : $this->tz = new DateTimeZone(date_default_timezone_get());